### PR TITLE
filter installed version by git commit SHA

### DIFF
--- a/src/reporter/core/views.py
+++ b/src/reporter/core/views.py
@@ -140,6 +140,17 @@ def index(request):
     except:
         pass
 
+    # filter by a git commit SHA in an untagged version
+    try:
+        git = request.GET.get('git') or None
+        if git:
+            # obspy version numbers contain only the first 10 characters of the
+            # git commit SHA
+            git = git[:10]
+            queryset = queryset.filter(installed__contains=git)
+    except:
+        pass
+
     # filter by node
     nodes = models.SelectedNode.objects.values_list('name', flat=True)
     try:


### PR DESCRIPTION
@barsch.. something like http://tests.obspy.org/?git=64eff8f3c5 to filter by the git commit SHA included in the version string could be useful in our docker testbots when it's known what commit is tested but not exactly how the full version information looks like..

(not sure if I missed anything, was just copy/pasting from the commit referenced by #17)
